### PR TITLE
[SDK 110] Null HTTP client check in middleware

### DIFF
--- a/include/enjinsdk/TrustedPlatformMiddleware.hpp
+++ b/include/enjinsdk/TrustedPlatformMiddleware.hpp
@@ -41,6 +41,9 @@ public:
     /// \brief Default destructor.
     ~TrustedPlatformMiddleware() = default;
 
+    /// \brief Closes the connection with the platform.
+    void close();
+
     /// \brief Returns the query registry used by the middleware.
     /// \return The query registry.
     [[nodiscard]] const graphql::GraphqlQueryRegistry& get_query_registry() const;
@@ -52,6 +55,10 @@ public:
     /// \brief Returns the Trusted Platform handler used by the middleware.
     /// \return The Trusted Platform handler.
     [[nodiscard]] const std::shared_ptr<http::TrustedPlatformHandler>& get_handler() const;
+
+    /// \brief Determines if the connection this middleware has with the platform is closed.
+    /// \return Whether the connection is closed.
+    [[nodiscard]] bool is_closed() const;
 
 private:
     graphql::GraphqlQueryRegistry query_registry;

--- a/src/PlayerClient.cpp
+++ b/src/PlayerClient.cpp
@@ -42,7 +42,7 @@ void PlayerClient::auth(const std::string& token) {
 }
 
 void PlayerClient::close() {
-    middleware.get_client()->stop();
+    middleware.close();
 }
 
 bool PlayerClient::is_authenticated() const {
@@ -50,7 +50,7 @@ bool PlayerClient::is_authenticated() const {
 }
 
 bool PlayerClient::is_closed() const {
-    return !middleware.get_client()->is_open();
+    return middleware.is_closed();
 }
 
 PlayerClient::PlayerClientBuilder PlayerClient::builder() {

--- a/src/ProjectClient.cpp
+++ b/src/ProjectClient.cpp
@@ -43,7 +43,7 @@ void ProjectClient::auth(const std::string& token) {
 }
 
 void ProjectClient::close() {
-    middleware.get_client()->stop();
+    middleware.close();
 }
 
 bool ProjectClient::is_authenticated() const {
@@ -51,7 +51,7 @@ bool ProjectClient::is_authenticated() const {
 }
 
 bool ProjectClient::is_closed() const {
-    return !middleware.get_client()->is_open();
+    return middleware.is_closed();
 }
 
 ProjectClient::ProjectClientBuilder ProjectClient::builder() {

--- a/src/TrustedPlatformMiddleware.cpp
+++ b/src/TrustedPlatformMiddleware.cpp
@@ -15,13 +15,26 @@
 
 #include "enjinsdk/TrustedPlatformMiddleware.hpp"
 
+#include <stdexcept>
 #include <utility>
 
 namespace enjin::sdk {
 
 TrustedPlatformMiddleware::TrustedPlatformMiddleware(std::unique_ptr<http::IHttpClient> client)
         : client(std::move(client)) {
+    if (TrustedPlatformMiddleware::client == nullptr) {
+        throw std::runtime_error("Nullptr for HTTP client on TrustedPlatformMiddleware construction.");
+    }
+
     TrustedPlatformMiddleware::client->start();
+}
+
+void TrustedPlatformMiddleware::close() {
+    if (client == nullptr) {
+        return;
+    }
+
+    client->stop();
 }
 
 const graphql::GraphqlQueryRegistry& TrustedPlatformMiddleware::get_query_registry() const {
@@ -34,6 +47,10 @@ const std::unique_ptr<http::IHttpClient>& TrustedPlatformMiddleware::get_client(
 
 const std::shared_ptr<http::TrustedPlatformHandler>& TrustedPlatformMiddleware::get_handler() const {
     return handler;
+}
+
+bool TrustedPlatformMiddleware::is_closed() const {
+    return client == nullptr || !client->is_open();
 }
 
 }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,3 +1,7 @@
+target_sources(${PROJECT_NAME}_tests
+        PRIVATE
+        TrustedPlatformMiddlewareTest.cpp)
+
 add_subdirectory(events)
 add_subdirectory(graphql)
 add_subdirectory(http)

--- a/test/unit/TrustedPlatformMiddlewareTest.cpp
+++ b/test/unit/TrustedPlatformMiddlewareTest.cpp
@@ -1,0 +1,84 @@
+/* Copyright 2021 Enjin Pte. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+#include "enjinsdk/TrustedPlatformMiddleware.hpp"
+#include "MockHttpClient.hpp"
+#include <memory>
+#include <utility>
+
+using namespace enjin::sdk;
+using namespace enjin::sdk::http;
+using namespace enjin::test::mocks;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+class TrustedPlatformMiddlewareTest : public ::testing::Test {
+public:
+    static TrustedPlatformMiddleware create_default_middleware() {
+        return TrustedPlatformMiddleware(std::make_unique<NiceMock<MockHttpClient>>());
+    }
+};
+
+TEST_F(TrustedPlatformMiddlewareTest, IsClosedHttpClientIsNotOpenReturnsTrue) {
+    // Arrange - Data
+    auto middleware = create_default_middleware();
+    auto& client = dynamic_cast<NiceMock<MockHttpClient>&>(*middleware.get_client());
+
+    // Arrange - Expectations
+    EXPECT_CALL(client, is_open()).WillOnce(Return(false));
+
+    // Act
+    bool actual = middleware.is_closed();
+
+    // Assert
+    ASSERT_TRUE(actual);
+}
+
+TEST_F(TrustedPlatformMiddlewareTest, IsClosedHttpClientIsOpenReturnsFalse) {
+    // Arrange - Data
+    auto middleware = create_default_middleware();
+    auto& client = dynamic_cast<NiceMock<MockHttpClient>&>(*middleware.get_client());
+
+    // Arrange - Expectations
+    EXPECT_CALL(client, is_open()).WillOnce(Return(true));
+
+    // Act
+    bool actual = middleware.is_closed();
+
+    // Assert
+    ASSERT_FALSE(actual);
+}
+
+TEST_F(TrustedPlatformMiddlewareTest, IsClosedAfterMoveReturnsTrue) {
+    // Arrange
+    auto middleware = create_default_middleware();
+    auto other = std::move(middleware);
+
+    // Act
+    bool actual = middleware.is_closed();
+
+    // Assert
+    ASSERT_TRUE(actual);
+}
+
+TEST_F(TrustedPlatformMiddlewareTest, CloseAfterMoveDoesNotFail) {
+    // Arrange
+    auto middleware = create_default_middleware();
+    auto other = std::move(middleware);
+
+    // Assert
+    ASSERT_NO_FATAL_FAILURE(middleware.close());
+}


### PR DESCRIPTION
- Added `close()` member function to `TrustedPlatformMiddleware`
- Added `is_closed()` member function to `TrustedPlatformMiddleware`
- `TrustedPlatformMiddleware` now checks if its HTTP client is null