### PR TITLE
[SDK 157] Deprecate Kovan for Goerli

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Create blockchain video games and applications using the C++ programming languag
 
 [Learn more](https://enjin.io/) about the Enjin blockchain platform.
 
-Sign up to Enjin Cloud: [Kovan (Testnet)](https://kovan.cloud.enjin.io/),
+Sign up to Enjin Cloud: [Goerli (Testnet)](https://goerli.cloud.enjin.io/),
 [Mainnet (Production)](https://cloud.enjin.io/) or [JumpNet](https://jumpnet.cloud.enjin.io/).
 
 ### Resources
@@ -107,10 +107,10 @@ using namespace enjin::sdk::models;
 using namespace enjin::sdk::project;
 
 int main() {
-    // Builds the project client to run on the Kovan test network.
-    // See: https://kovan.cloud.enjin.io to sign up for the test network.
+    // Builds the project client to run on the Goerli test network.
+    // See: https://goerli.cloud.enjin.io to sign up for the test network.
     std::unique_ptr<ProjectClient> client = ProjectClientBuilder()
-        .base_uri(KOVAN) // From EnjinHosts
+        .base_uri(GOERLI) // From EnjinHosts
         .build();
 
     // Creates the request to authenticate the client.

--- a/include/enjinsdk/EnjinHosts.hpp
+++ b/include/enjinsdk/EnjinHosts.hpp
@@ -22,7 +22,7 @@
 namespace enjin::sdk {
 
 /// \brief The URI for the Enjin Platform on the Goerli test network.
-static constexpr char GOERLI[] = "https://kovan.cloud.enjin.io";
+static constexpr char GOERLI[] = "https://goerli.cloud.enjin.io";
 
 /// \brief The URI for the Enjin Platform on the Kovan test network.
 /// \deprecated This host may no longer be supported. Use the GOERLI host.

--- a/include/enjinsdk/EnjinHosts.hpp
+++ b/include/enjinsdk/EnjinHosts.hpp
@@ -21,13 +21,18 @@
 
 namespace enjin::sdk {
 
-/// \brief The URI for the kovan Enjin Cloud.
+/// \brief The URI for the Enjin Platform on the Goerli test network.
+static constexpr char GOERLI[] = "https://kovan.cloud.enjin.io";
+
+/// \brief The URI for the Enjin Platform on the Kovan test network.
+/// \deprecated This host may no longer be supported. Use the GOERLI host.
+[[deprecated("Kovan is deprecated, please use Goerli instead for a test network.")]]
 static constexpr char KOVAN[] = "https://kovan.cloud.enjin.io";
 
-/// \brief The URI for the main Enjin Cloud.
+/// \brief The URI for the Enjin Platform on the main network.
 static constexpr char MAIN_NET[] = "https://cloud.enjin.io";
 
-/// \brief The URI for the JumpNet network.
+/// \brief The URI for the Enjin Platform on the JumpNet network.
 static constexpr char JUMP_NET[] = "https://jumpnet.cloud.enjin.io";
 
 }

--- a/include/enjinsdk/EnjinHosts.hpp
+++ b/include/enjinsdk/EnjinHosts.hpp
@@ -24,11 +24,6 @@ namespace enjin::sdk {
 /// \brief The URI for the Enjin Platform on the Goerli test network.
 static constexpr char GOERLI[] = "https://goerli.cloud.enjin.io";
 
-/// \brief The URI for the Enjin Platform on the Kovan test network.
-/// \deprecated This host may no longer be supported. Use the GOERLI host.
-[[deprecated("Kovan is deprecated, please use Goerli instead for a test network.")]]
-static constexpr char KOVAN[] = "https://kovan.cloud.enjin.io";
-
 /// \brief The URI for the Enjin Platform on the main network.
 static constexpr char MAIN_NET[] = "https://cloud.enjin.io";
 

--- a/test/include/ChannelsTestSuite.hpp
+++ b/test/include/ChannelsTestSuite.hpp
@@ -22,7 +22,7 @@ namespace enjin::test::suites {
 
 class ChannelsTestSuite {
 public:
-    constexpr static char PLATFORM_JSON[] = R"({"id":1,"name":"","network":"kovan","contracts":{},"notifications":{}})";
+    constexpr static char PLATFORM_JSON[] = R"({"id":1,"name":"","network":"test","contracts":{},"notifications":{}})";
 
     static enjin::sdk::models::Platform create_default_platform() {
         enjin::sdk::models::Platform platform;

--- a/test/unit/events/AssetChannelTest.cpp
+++ b/test/unit/events/AssetChannelTest.cpp
@@ -27,7 +27,7 @@ class AssetChannelTest : public ChannelsTestSuite,
 
 TEST_F(AssetChannelTest, ChannelReturnsExpectedString) {
     // Arrange
-    const std::string expected("enjincloud.kovan.asset.1");
+    const std::string expected("enjincloud.test.asset.1");
     AssetChannel channel(create_default_platform(), "1");
 
     // Act

--- a/test/unit/events/EventTypeDefTest.cpp
+++ b/test/unit/events/EventTypeDefTest.cpp
@@ -167,6 +167,6 @@ INSTANTIATE_TEST_SUITE_P(DefNotInTypesTestCases,
 INSTANTIATE_TEST_SUITE_P(FilterByChannelTypesTestCases,
                          EventTypeDefFilterByChannelTypes,
                          testing::Values("player",
-                                         "enjincloud.kovan.wallet.0x0",
-                                         "enjincloud.mainnet.project.1234",
+                                         "enjincloud.test.wallet.0x0",
+                                         "enjincloud.test.project.1234",
                                          "xyz"));

--- a/test/unit/events/PlayerChannelTest.cpp
+++ b/test/unit/events/PlayerChannelTest.cpp
@@ -27,7 +27,7 @@ class PlayerChannelTest : public ChannelsTestSuite,
 
 TEST_F(PlayerChannelTest, ChannelReturnsExpectedString) {
     // Arrange
-    const std::string expected("enjincloud.kovan.project.1.player.1");
+    const std::string expected("enjincloud.test.project.1.player.1");
     PlayerChannel channel(create_default_platform(), "1", "1");
 
     // Act

--- a/test/unit/events/ProjectChannelTest.cpp
+++ b/test/unit/events/ProjectChannelTest.cpp
@@ -27,7 +27,7 @@ class ProjectChannelTest : public ChannelsTestSuite,
 
 TEST_F(ProjectChannelTest, ChannelReturnsExpectedString) {
     // Arrange
-    const std::string expected("enjincloud.kovan.project.1");
+    const std::string expected("enjincloud.test.project.1");
     ProjectChannel channel(create_default_platform(), "1");
 
     // Act

--- a/test/unit/events/PusherEventServiceTest.cpp
+++ b/test/unit/events/PusherEventServiceTest.cpp
@@ -29,7 +29,7 @@ using namespace enjin::test::mocks;
 class PusherEventServiceTest : public testing::Test {
 public:
     static constexpr char PLATFORM_JSON[] =
-            R"({"network":"kovan","notifications":{"pusher":{"key":"1","options":{"cluster":"mt1","encrypted":true}}}})";
+            R"({"network":"test","notifications":{"pusher":{"key":"1","options":{"cluster":"mt1","encrypted":true}}}})";
 
     static constexpr EventType EVENT_TYPES[] = {
             EventType::UNKNOWN,

--- a/test/unit/events/PusherEventServiceWebsocketTest.cpp
+++ b/test/unit/events/PusherEventServiceWebsocketTest.cpp
@@ -42,7 +42,7 @@ public:
     static constexpr char DEFAULT_ASSET[] = "0x0";
     static constexpr char DEFAULT_WALLET[] = "0x1";
     static constexpr char PLATFORM_JSON[] =
-            R"({"network":"kovan","notifications":{"pusher":{"key":"1","options":{"cluster":"mt1","encrypted":true}}}})";
+            R"({"network":"test","notifications":{"pusher":{"key":"1","options":{"cluster":"mt1","encrypted":true}}}})";
 
     MockWebsocketServer mock_server;
 

--- a/test/unit/events/WalletChannelTest.cpp
+++ b/test/unit/events/WalletChannelTest.cpp
@@ -27,7 +27,7 @@ class WalletChannelTest : public ChannelsTestSuite,
 
 TEST_F(WalletChannelTest, ChannelReturnsExpectedString) {
     // Arrange
-    const std::string expected("enjincloud.kovan.wallet.1");
+    const std::string expected("enjincloud.test.wallet.1");
     WalletChannel channel(create_default_platform(), "1");
 
     // Act


### PR DESCRIPTION
- Added Goerli host to `EnjinHosts`
- Deprecated Kovan host
- Updated `README.md` to use Goerli instead of Kovan